### PR TITLE
Fixed go-test-coverage and add k8s versions to do compatible tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
           flags: unittests
 
   scenarios_tests:
-    name: Test various Envoy + SMI configuration scenarios
+    name: Test various Sidecar + SMI configuration scenarios
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ kind-reset:
 
 .PHONY: test-e2e
 test-e2e: DOCKER_BUILDX_OUTPUT=type=docker
-test-e2e:
+test-e2e: docker-build-osm build-osm docker-build-tcp-echo-server
 	go test ./tests/e2e $(E2E_FLAGS_DEFAULT) $(E2E_FLAGS)
 
 .env:

--- a/cmd/cli/version_latest.go
+++ b/cmd/cli/version_latest.go
@@ -11,7 +11,7 @@ import (
 )
 
 func getLatestReleaseVersion() (string, error) {
-	url := "https://api.github.com/repos/openservicemesh/osm/releases/latest"
+	url := "https://api.github.com/repos/flomesh-io/osm-edge/releases/latest"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to create GET request for latest release version from %s", url)
@@ -49,7 +49,7 @@ func outputLatestReleaseVersion(out io.Writer, latestRelease string, currentRele
 		return err
 	}
 	if current.LessThan(latest) {
-		fmt.Fprintf(out, "\nOSM %s is now available. Please see https://github.com/openservicemesh/osm/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n", latestRelease)
+		fmt.Fprintf(out, "\nOSM %s is now available. Please see https://github.com/flomesh-io/osm-edge/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n", latestRelease)
 	}
 	return nil
 }

--- a/cmd/cli/version_latest_test.go
+++ b/cmd/cli/version_latest_test.go
@@ -35,7 +35,7 @@ func TestOutputLatestReleaseVersion(t *testing.T) {
 			current: "v1.21.4",
 			latest:  "v1.21.5",
 			err:     nil,
-			output:  "\nOSM v1.21.5 is now available. Please see https://github.com/openservicemesh/osm/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n",
+			output:  "\nOSM v1.21.5 is now available. Please see https://github.com/flomesh-io/osm-edge/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n",
 		},
 		{
 			name:    "current is latest version",

--- a/pipy/Makefile
+++ b/pipy/Makefile
@@ -23,6 +23,9 @@ k8s-tools: install-docker
 golang:
 	make -f scripts/Makefile.golang
 
+kind-node-images:
+	scripts/kind-node-images.sh ${OSM_HOME} ${BUILDARCH} ${BUILDOS}
+
 .env:
 	scripts/env.sh ${OSM_HOME} ${BUILDARCH} ${BUILDOS}
 

--- a/pipy/scripts/e2e.sh
+++ b/pipy/scripts/e2e.sh
@@ -33,8 +33,11 @@ allCases=(
 "HTTP ingress with IngressBackend"
 "When OSM is Installed"
 "Test IP range exclusion"
-"Version v1.22.8"
-"Version v1.21.11"
+"Version v1.23.6"
+"Version v1.22.9"
+"Version v1.21.12"
+"Version v1.20.10"
+"Version v1.19.16"
 "#Custom WASM metrics between one client pod and one server"
 "Multiple service ports"
 "Multiple services matching same pod"
@@ -69,5 +72,5 @@ allCases=(
 # shellcheck disable=SC2068
 for item in "${allCases[@]}"; do
   echo -e "Testing $item ..."
-  E2E_FLAGS="-ginkgo.focus='$item' --timeout=0" make test-e2e 2>/dev/null | grep 'Passed.*Failed.*Skipped'
+  TIMEOUT=600s E2E_FLAGS="-ginkgo.focus='$item' --timeout=0" make test-e2e 2>/dev/null | grep 'Passed.*Failed.*Skipped'
 done

--- a/pipy/scripts/e2e.sh
+++ b/pipy/scripts/e2e.sh
@@ -36,7 +36,7 @@ allCases=(
 "Version v1.23.6"
 "Version v1.22.9"
 "Version v1.21.12"
-"Version v1.20.10"
+"Version v1.20.15"
 "Version v1.19.16"
 "#Custom WASM metrics between one client pod and one server"
 "Multiple service ports"

--- a/pipy/scripts/kind-node-images.sh
+++ b/pipy/scripts/kind-node-images.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "$1" ]; then
+  echo "Error: expected one argument OSM_HOME"
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Error: expected one argument OS_ARCH"
+  exit 1
+fi
+
+if [ -z "$3" ]; then
+  echo "Error: expected one argument OS"
+  exit 1
+fi
+
+OSM_HOME=$1
+BUILD_ARCH=$2
+BUILD_OS=$3
+
+wget -q https://registry.hub.docker.com/v1/repositories/kindest/node-${BUILD_ARCH}/tags -O - | jq -r '.[].name' | sort -u

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -1,6 +1,7 @@
 package debugger
 
 import (
+	"github.com/openservicemesh/osm/pkg/sidecar"
 	"net/http"
 	"net/http/pprof"
 
@@ -39,7 +40,7 @@ func (ds DebugConfig) GetHandlers() map[string]http.Handler {
 
 // NewDebugConfig returns an implementation of DebugConfig interface.
 func NewDebugConfig(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger,
-	proxyRegistry ProxyRegistry, kubeConfig *rest.Config, kubeClient kubernetes.Interface,
+	proxyRegistry sidecar.ProxyRegistry, kubeConfig *rest.Config, kubeClient kubernetes.Interface,
 	cfg configurator.Configurator, kubeController k8s.Controller, msgBroker *messaging.Broker) DebugConfig {
 	return DebugConfig{
 		certDebugger:        certDebugger,

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -2,6 +2,7 @@
 package debugger
 
 import (
+	"github.com/openservicemesh/osm/pkg/sidecar"
 	"time"
 
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
@@ -26,7 +27,7 @@ type DebugConfig struct {
 	certDebugger        CertificateManagerDebugger
 	xdsDebugger         XDSDebugger
 	meshCatalogDebugger MeshCatalogDebugger
-	proxyRegistry       ProxyRegistry
+	proxyRegistry       sidecar.ProxyRegistry
 	kubeConfig          *rest.Config
 	kubeClient          kubernetes.Interface
 	kubeController      k8s.Controller
@@ -50,14 +51,4 @@ type MeshCatalogDebugger interface {
 type XDSDebugger interface {
 	// GetXDSLog returns a log of the XDS responses sent to Envoy proxies.
 	GetXDSLog() *map[certificate.CommonName]map[envoy.TypeURI][]time.Time
-}
-
-// ProxyRegistry is an interface providing adaptiving Registries of multiple sidecars
-type ProxyRegistry interface {
-	ListConnectedProxies() map[certificate.CommonName]Proxy
-}
-
-// Proxy is an interface providing adaptiving proxies of multiple sidecars
-type Proxy interface {
-	GetConnectedAt() time.Time
 }

--- a/pkg/envoy/registry/debugger.go
+++ b/pkg/envoy/registry/debugger.go
@@ -2,12 +2,12 @@ package registry
 
 import (
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/debugger"
+	"github.com/openservicemesh/osm/pkg/sidecar"
 )
 
 // ListConnectedProxies lists the Envoy proxies already connected and the time they first connected.
-func (pr *ProxyRegistry) ListConnectedProxies() map[certificate.CommonName]debugger.Proxy {
-	proxies := make(map[certificate.CommonName]debugger.Proxy)
+func (pr *ProxyRegistry) ListConnectedProxies() map[certificate.CommonName]sidecar.Proxy {
+	proxies := make(map[certificate.CommonName]sidecar.Proxy)
 	pr.connectedProxies.Range(func(cnIface, propsIface interface{}) bool {
 		cn := cnIface.(certificate.CommonName)
 		props := propsIface.(connectedProxy)

--- a/pkg/pipy/registry/debugger.go
+++ b/pkg/pipy/registry/debugger.go
@@ -2,12 +2,12 @@ package registry
 
 import (
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/debugger"
+	"github.com/openservicemesh/osm/pkg/sidecar"
 )
 
 // ListConnectedProxies lists the Sidecar proxies already connected and the time they first connected.
-func (pr *ProxyRegistry) ListConnectedProxies() map[certificate.CommonName]debugger.Proxy {
-	proxies := make(map[certificate.CommonName]debugger.Proxy)
+func (pr *ProxyRegistry) ListConnectedProxies() map[certificate.CommonName]sidecar.Proxy {
+	proxies := make(map[certificate.CommonName]sidecar.Proxy)
 	pr.connectedProxies.Range(func(cnIface, propsIface interface{}) bool {
 		cn := cnIface.(certificate.CommonName)
 		props := propsIface.(connectedProxy)

--- a/pkg/sidecar/types.go
+++ b/pkg/sidecar/types.go
@@ -1,0 +1,16 @@
+package sidecar
+
+import (
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"time"
+)
+
+// Proxy is an interface providing adaptiving proxies of multiple sidecars
+type Proxy interface {
+	GetConnectedAt() time.Time
+}
+
+// ProxyRegistry is an interface providing adaptiving Registries of multiple sidecars
+type ProxyRegistry interface {
+	ListConnectedProxies() map[certificate.CommonName]Proxy
+}

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -18,11 +18,20 @@ var _ = OSMDescribe("Test HTTP traffic for different k8s versions",
 		Bucket: 6,
 	},
 	func() {
-		Context("Version v1.22.8", func() {
-			testK8sVersion("v1.22.8")
+		Context("Version v1.23.6", func() {
+			testK8sVersion("v1.23.6")
 		})
-		Context("Version v1.21.11", func() {
-			testK8sVersion("v1.21.11")
+		Context("Version v1.22.9", func() {
+			testK8sVersion("v1.22.9")
+		})
+		Context("Version v1.21.12", func() {
+			testK8sVersion("v1.21.12")
+		})
+		Context("Version v1.20.15", func() {
+			testK8sVersion("v1.20.15")
+		})
+		Context("Version v1.19.16", func() {
+			testK8sVersion("v1.19.16")
 		})
 	})
 
@@ -66,7 +75,7 @@ func testK8sVersion(version string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 600*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no service for client */)
 

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -44,12 +44,12 @@ var _ = OSMDescribe("Upgrade from latest",
 			const releaseName = "osm"
 			i := action.NewInstall(helmCfg)
 
-			i.ChartPathOptions.RepoURL = "https://openservicemesh.github.io/osm"
+			i.ChartPathOptions.RepoURL = "https://flomesh-io.github.io/osm-edge"
 			// On the main branch, this should refer to the latest release. On
 			// release branches, it should specify the most recent patch of the
 			// previous minor release. e.g. on the release-v1.0 branch, this
 			// should be "0.11".
-			i.Version = "1.0"
+			i.Version = "1.1.0"
 			i.Namespace = Td.OsmNamespace
 			i.Wait = true
 			i.ReleaseName = releaseName


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
1.Fixed go-test-coverage
2.Fixed the repo address of the request to get the latest version of the API
3.Add k8s versions to do compatible tests: v1.23.6,v1.22.9,v1.21.12,v1.20.15,v1.19.16
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?  no
    -   Did you notify the maintainers and provide attribution? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?no