### PR TITLE
remove arch from node selector from chart template

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -87,7 +87,6 @@ spec:
              kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found;
              kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-controller --ignore-not-found;
       nodeSelector:
-        kubernetes.io/arch: {{ .Values.osm.nodeSelector.arch }}
         kubernetes.io/os: {{ .Values.osm.nodeSelector.os }}
 {{- if .Values.osm.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -25,7 +25,6 @@ spec:
       {{- end }}
       serviceAccountName: osm-grafana
       nodeSelector:
-        kubernetes.io/arch: {{ .Values.osm.nodeSelector.arch }}
         kubernetes.io/os: {{ .Values.osm.nodeSelector.os }}
       containers:
         - name: grafana

--- a/charts/osm/templates/jaeger-deployment.yaml
+++ b/charts/osm/templates/jaeger-deployment.yaml
@@ -23,7 +23,6 @@ spec:
       {{- end }}
       serviceAccountName: jaeger
       nodeSelector:
-        kubernetes.io/arch: {{ .Values.osm.nodeSelector.arch }}
         kubernetes.io/os: {{ .Values.osm.nodeSelector.os }}
       containers:
       - name: jaeger

--- a/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
@@ -19,7 +19,6 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}
       nodeSelector:
-        kubernetes.io/arch: {{ .Values.osm.nodeSelector.arch }}
         kubernetes.io/os: {{ .Values.osm.nodeSelector.os }}
       initContainers:
         - name: osm-multicluster-gateway-init

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -23,7 +23,6 @@ spec:
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       nodeSelector:
-        kubernetes.io/arch: {{ .Values.osm.nodeSelector.arch }}
         kubernetes.io/os: {{ .Values.osm.nodeSelector.os }}
       containers:
       - name: prometheus


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

when osm cli and target cluster are not the same architecture, the pods of Prometheus, Grafana, Jaeger and cleanup job will key on pending.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [x] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
   No.
2. Is this a breaking change?
   No.
3. Has documentation corresponding to this change been updated in the [osm-edge-docs](https://github.com/flomesh-io/osm-docs/) repo (if applicable)?
    NA.