### PR TITLE
Fix release v1.2 ubi8

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -195,7 +195,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.outboundIPRangeExclusionList | list | `[]` | Specifies a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
 | osm.outboundIPRangeInclusionList | list | `[]` | Specifies a global list of IP ranges to include for outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
 | osm.outboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
-| osm.pipyRepoImage | string | `"quay.io/flomesh/pipy-repo-ubi8:0.70.0-46"` | Pipy repo image for Pipy sidecar's proxy control plane container |
+| osm.pipyRepoImage | string | `"quay.io/flomesh/pipy-ubi8:0.70.0-46"` | Pipy repo image for Pipy sidecar's proxy control plane container |
 | osm.preinstall.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"kubernetes.io/os"` |  |
 | osm.preinstall.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"In"` |  |
 | osm.preinstall.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0] | string | `"linux"` |  |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -70,7 +70,7 @@ osm:
   # -- Curl image for control plane init container
   curlImage: quay.io/flomesh/curl-ubi8:7.84.0
   # -- Pipy repo image for Pipy sidecar's proxy control plane container
-  pipyRepoImage: quay.io/flomesh/pipy-repo-ubi8:0.70.0-46
+  pipyRepoImage: quay.io/flomesh/pipy-ubi8:0.70.0-46
   #
   # -- OSM controller parameters
   osmController:

--- a/dockerfiles/Dockerfile.osm-edge-crds
+++ b/dockerfiles/Dockerfile.osm-edge-crds
@@ -1,8 +1,8 @@
-ARG TARGETPLATFORM
 FROM registry.access.redhat.com/ubi8-minimal
+ARG TARGETPLATFORM
 # Talking to the internet in an arm64 container doesn't seem to work from a
 # amd64 Mac, so download the kubectl binary in a stage running the native arch.
-RUN curl https://dl.k8s.io/release/v1.22.2/bin/$TARGETPLATFORM/kubectl -o /bin/kubectl && chmod +x /bin/kubectl
+RUN curl --insecure -L https://dl.k8s.io/release/v1.22.2/bin/$TARGETPLATFORM/kubectl -o /bin/kubectl && chmod +x /bin/kubectl
 RUN microdnf update && microdnf install shadow-utils
 RUN groupadd osm && useradd -G osm osm-edge
 USER osm-edge


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
1. Change pipy-repo-ubi8:0.70.0-46 to pipy-ubi8:0.70.0-46
2. Fix osm-edge-crds issue
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
N/A
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no

3. Is this a breaking change? no

4. Has documentation corresponding to this change been updated in the [osm-edge-docs](https://github.com/flomesh-io/osm-docs/) repo (if applicable)? no