### PR TITLE
move sidecar's envs into config.json

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -338,6 +338,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.repoServer.ipaddr | string | `"127.0.0.1"` | ipaddr of host/service where Pipy RepoServer is installed |
 | osm.repoServer.standalone | bool | `false` | if false , Pipy RepoServer is installed within osmController pod. |
 | osm.sidecarClass | string | `"pipy"` | The class of the OSM Sidecar Driver |
+| osm.sidecarDisabledMTLS | bool | `false` | Sidecar runs without mTLS |
 | osm.sidecarDrivers | list | `[{"proxyServerPort":6060,"sidecarImage":"flomesh/pipy:0.90.3-38","sidecarName":"pipy"},{"proxyServerPort":15128,"sidecarImage":"envoyproxy/envoy:v1.19.3","sidecarName":"envoy","sidecarWindowsImage":"envoyproxy/envoy-windows:latest"}]` | Sidecar drivers supported by osm-edge |
 | osm.sidecarDrivers[0].proxyServerPort | int | `6060` | Remote destination port on which the Discovery Service listens for new connections from Sidecars. |
 | osm.sidecarDrivers[0].sidecarImage | string | `"flomesh/pipy:0.90.3-38"` | Sidecar image for Linux workloads |

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -17,6 +17,7 @@ data:
         "sidecarTimeout": {{.Values.osm.sidecarTimeout | mustToJson}},
         "sidecarClass": {{.Values.osm.sidecarClass | mustToJson }},
         "sidecarImage": {{.Values.osm.sidecarImage | mustToJson }},
+        "sidecarDisabledMTLS": {{.Values.osm.sidecarDisabledMTLS | mustToJson }},
         "sidecarDrivers": {{.Values.osm.sidecarDrivers | mustToJson }},
         "localProxyMode": {{.Values.osm.localProxyMode | mustToJson}},
         "localDNSProxy": {{.Values.osm.localDNSProxy | mustToJson}}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -506,6 +506,15 @@
                         "flomesh/pipy-nightly:latest"
                     ]
                 },
+                "sidecarDisabledMTLS": {
+                    "$id": "#/properties/osm/properties/sidecarDisabledMTLS",
+                    "type": "boolean",
+                    "title": "The sidecarDisabledMTLS schema",
+                    "description": "The proxy side car runs without mTLS",
+                    "examples": [
+                        false
+                    ]
+                },
                 "sidecarWindowsImage": {
                     "$id": "#/properties/osm/properties/sidecarWindowsImage",
                     "type": "string",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -56,6 +56,8 @@ osm:
   sidecarClass: pipy
   # -- Sidecar image for Linux workloads
   sidecarImage: ""
+  # -- Sidecar runs without mTLS
+  sidecarDisabledMTLS: false
   # -- Sidecar drivers supported by osm-edge
   sidecarDrivers:
     - sidecarName: pipy

--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -93,6 +93,9 @@ spec:
                     sidecarWindowsImage:
                       description: Image for the sidecar on Windows workers
                       type: string
+                    sidecarDisabledMTLS:
+                      description: Disabled mTLS
+                      type: boolean
                     initContainerImage:
                       description: Image for the init container
                       type: string
@@ -534,6 +537,9 @@ spec:
                     sidecarWindowsImage:
                       description: Image for the sidecar on Windows workers
                       type: string
+                    sidecarDisabledMTLS:
+                      description: Disabled mTLS
+                      type: boolean
                     initContainerImage:
                       description: Image for the init container
                       type: string

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -63,6 +63,9 @@ type SidecarSpec struct {
 	// SidecarImage defines the container image used for the proxy sidecar.
 	SidecarImage string `json:"sidecarImage,omitempty"`
 
+	// SidecarDisabledMTLS defines whether mTLS is disabled.
+	SidecarDisabledMTLS bool `json:"sidecarDisabledMTLS"`
+
 	// SidecarWindowsImage defines the windows container image used for the proxy sidecar.
 	SidecarWindowsImage string `json:"sideWindowsImage,omitempty"`
 

--- a/pkg/apis/config/v1alpha2/mesh_config.go
+++ b/pkg/apis/config/v1alpha2/mesh_config.go
@@ -85,6 +85,9 @@ type SidecarSpec struct {
 	// SidecarImage defines the container image used for the proxy sidecar.
 	SidecarImage string `json:"sidecarImage,omitempty"`
 
+	// SidecarDisabledMTLS defines whether mTLS is disabled.
+	SidecarDisabledMTLS bool `json:"sidecarDisabledMTLS"`
+
 	// SidecarWindowsImage defines the windows container image used for the proxy sidecar.
 	SidecarWindowsImage string `json:"SidecarImageWindowsImage,omitempty"`
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -309,13 +309,15 @@ func (c *Client) GetProxyServerPort() uint32 {
 
 // GetSidecarDisabledMTLS returns the status of mTLS
 func (c *Client) GetSidecarDisabledMTLS() bool {
-	disabledMTLS := false
-	sidecarClass := c.getMeshConfig().Spec.Sidecar.SidecarClass
-	sidecarDrivers := c.getMeshConfig().Spec.Sidecar.SidecarDrivers
-	for _, sidecarDriver := range sidecarDrivers {
-		if strings.EqualFold(strings.ToLower(sidecarClass), strings.ToLower(sidecarDriver.SidecarName)) {
-			disabledMTLS = sidecarDriver.SidecarDisabledMTLS
-			break
+	disabledMTLS := c.getMeshConfig().Spec.Sidecar.SidecarDisabledMTLS
+	if !disabledMTLS {
+		sidecarClass := c.getMeshConfig().Spec.Sidecar.SidecarClass
+		sidecarDrivers := c.getMeshConfig().Spec.Sidecar.SidecarDrivers
+		for _, sidecarDriver := range sidecarDrivers {
+			if strings.EqualFold(strings.ToLower(sidecarClass), strings.ToLower(sidecarDriver.SidecarName)) {
+				disabledMTLS = sidecarDriver.SidecarDisabledMTLS
+				break
+			}
 		}
 	}
 	return disabledMTLS

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -347,6 +347,7 @@ func getProxyUpdateEvent(msg events.PubSubMessage) *proxyUpdateEvent {
 			prevSpec.Observability.RemoteLogging != newSpec.Observability.RemoteLogging ||
 			prevSpec.Sidecar.LogLevel != newSpec.Sidecar.LogLevel ||
 			prevSpec.Sidecar.SidecarTimeout != newSpec.Sidecar.SidecarTimeout ||
+			prevSpec.Sidecar.LocalDNSProxy != newSpec.Sidecar.LocalDNSProxy ||
 			prevSpec.Traffic.InboundExternalAuthorization.Enable != newSpec.Traffic.InboundExternalAuthorization.Enable ||
 			// Only trigger an update on InboundExternalAuthorization field changes if the new spec has the 'Enable' flag set to true.
 			(newSpec.Traffic.InboundExternalAuthorization.Enable && (prevSpec.Traffic.InboundExternalAuthorization != newSpec.Traffic.InboundExternalAuthorization)) ||

--- a/pkg/sidecar/providers/pipy/driver/pipy_container.go
+++ b/pkg/sidecar/providers/pipy/driver/pipy_container.go
@@ -155,71 +155,7 @@ func getPipySidecarContainerSpec(injCtx *driver.InjectorContext, pod *corev1.Pod
 		},
 	}
 
-	if injCtx.Configurator.IsTracingEnabled() {
-		if len(injCtx.Configurator.GetTracingHost()) > 0 && injCtx.Configurator.GetTracingPort() > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "TRACING_ADDRESS",
-				Value: fmt.Sprintf("%s:%d", injCtx.Configurator.GetTracingHost(), injCtx.Configurator.GetTracingPort()),
-			})
-		}
-		if len(injCtx.Configurator.GetTracingEndpoint()) > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "TRACING_ENDPOINT",
-				Value: injCtx.Configurator.GetTracingEndpoint(),
-			})
-		}
-		sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-			Name:  "TRACING_SAMPLED_FRACTION",
-			Value: fmt.Sprintf("%0.2f", injCtx.Configurator.GetTracingSampledFraction()),
-		})
-	}
-
-	if injCtx.Configurator.IsRemoteLoggingEnabled() {
-		sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-			Name:  "REMOTE_LOGGING_LEVEL",
-			Value: fmt.Sprintf("%d", injCtx.Configurator.GetRemoteLoggingLevel()),
-		})
-		if len(injCtx.Configurator.GetRemoteLoggingHost()) > 0 && injCtx.Configurator.GetRemoteLoggingPort() > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "REMOTE_LOGGING_ADDRESS",
-				Value: fmt.Sprintf("%s:%d", injCtx.Configurator.GetRemoteLoggingHost(), injCtx.Configurator.GetRemoteLoggingPort()),
-			})
-		}
-		if len(injCtx.Configurator.GetRemoteLoggingEndpoint()) > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "REMOTE_LOGGING_ENDPOINT",
-				Value: injCtx.Configurator.GetRemoteLoggingEndpoint(),
-			})
-		}
-		if len(injCtx.Configurator.GetRemoteLoggingAuthorization()) > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "REMOTE_LOGGING_AUTHORIZATION",
-				Value: injCtx.Configurator.GetRemoteLoggingAuthorization(),
-			})
-		}
-		sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-			Name:  "REMOTE_LOGGING_SAMPLED_FRACTION",
-			Value: fmt.Sprintf("%0.2f", injCtx.Configurator.GetRemoteLoggingSampledFraction()),
-		})
-	}
-
 	if injCtx.Configurator.IsLocalDNSProxyEnabled() {
-		sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-			Name:  "LOCAL_DNS_PROXY",
-			Value: "true",
-		})
-		if len(injCtx.Configurator.GetLocalDNSProxyPrimaryUpstream()) > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "LOCAL_DNS_PROXY_PRIMARY_UPSTREAM",
-				Value: injCtx.Configurator.GetLocalDNSProxyPrimaryUpstream(),
-			})
-		}
-		if len(injCtx.Configurator.GetLocalDNSProxySecondaryUpstream()) > 0 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{
-				Name:  "LOCAL_DNS_PROXY_SECONDARY_UPSTREAM",
-				Value: injCtx.Configurator.GetLocalDNSProxySecondaryUpstream(),
-			})
-		}
 		if osmControllerSvc, err := getOSMControllerSvc(injCtx.KubeClient, injCtx.OsmNamespace); err == nil {
 			pod.Spec.HostAliases = append(pod.Spec.HostAliases, corev1.HostAlias{
 				IP:        osmControllerSvc.Spec.ClusterIP,

--- a/pkg/sidecar/providers/pipy/repo/codebase/dns-main.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/dns-main.js
@@ -1,7 +1,7 @@
 ((
   config = pipy.solve('config.js'),
   dnsServers = { primary: config?.Spec?.LocalDNSProxy?.UpstreamDNSServers?.Primary, secondary: config?.Spec?.LocalDNSProxy?.UpstreamDNSServers?.Secondary },
-  dnsSvcAddress = (dnsServers?.primary || dnsServers?.secondary || os.env.LOCAL_DNS_PROXY_PRIMARY_UPSTREAM || '10.96.0.10') + ":53",
+  dnsSvcAddress = (dnsServers?.primary || dnsServers?.secondary || '10.96.0.10') + ":53",
   dnsRecordSets = {},
 ) => (
   config?.DNSResolveDB && (

--- a/pkg/sidecar/providers/pipy/repo/codebase/logging.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/logging.js
@@ -7,10 +7,10 @@
       name,
       pod,
     } = pipy.solve('utils.js'),
-    address = os.env.REMOTE_LOGGING_ADDRESS,
-    tracingLimitedID = os.env.REMOTE_LOGGING_SAMPLED_FRACTION && (os.env.REMOTE_LOGGING_SAMPLED_FRACTION * Math.pow(2, 63)),
+    address = config?.Spec?.Observability?.remoteLogging?.address,
+    tracingLimitedID = config?.Spec?.Observability?.remoteLogging?.sampledFraction && (+config.Spec.Observability.remoteLogging.sampledFraction * Math.pow(2, 63)),
     logLogging = address && new logging.JSONLogger('access-logger').toHTTP('http://' + address +
-      (os.env.REMOTE_LOGGING_ENDPOINT || '/?query=insert%20into%20log(message)%20format%20JSONAsString'), {
+      (config?.Spec?.Observability?.remoteLogging?.endpoint || '/?query=insert%20into%20log(message)%20format%20JSONAsString'), {
       batch: {
         timeout: 1,
         interval: 1,
@@ -20,7 +20,7 @@
       },
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': os.env.REMOTE_LOGGING_AUTHORIZATION || ''
+        'Authorization': config?.Spec?.Observability?.remoteLogging?.authorization || ''
       }
     }).log,
     {
@@ -56,8 +56,8 @@
           sampled = false,
         ) => (
           msg?.head?.headers && (
-            (config?.Spec?.RemoteLoggingLevel > 0) ? (
-              ((config.Spec.RemoteLoggingLevel === 2 && isOutbound) || !msg.head.headers['x-b3-traceid']) && (
+            (config?.Spec?.Observability?.remoteLogging?.level > 0) ? (
+              ((config.Spec.Observability.remoteLogging.level === 2 && isOutbound) || !msg.head.headers['x-b3-traceid']) && (
                 initTracingHeaders(msg.head.headers)
               ),
               sampled = (!tracingLimitedID || toInt63(msg.head.headers['x-b3-traceid']) < tracingLimitedID)

--- a/pkg/sidecar/providers/pipy/repo/codebase/main.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/main.js
@@ -55,7 +55,7 @@
 // Local DNS server
 //
 .branch(
-  Boolean(os.env.LOCAL_DNS_PROXY), (
+  Boolean(config?.Spec?.LocalDNSProxy), (
     $=>$
     .listen('127.0.0.153:5300', { protocol: 'udp', transparent: true })
     .chain(['dns-main.js'])

--- a/pkg/sidecar/providers/pipy/repo/codebase/tracing.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/tracing.js
@@ -1,14 +1,15 @@
 (
   (
+    config = pipy.solve('config.js'),
     {
       namespace,
       kind,
       name,
       pod,
     } = pipy.solve('utils.js'),
-    tracingAddress = os.env.TRACING_ADDRESS,
-    tracingEndpoint = (os.env.TRACING_ENDPOINT || '/api/v2/spans'),
-    tracingLimitedID = os.env.TRACING_SAMPLED_FRACTION && (os.env.TRACING_SAMPLED_FRACTION * Math.pow(2, 63)),
+    tracingAddress = config?.Spec?.Observability?.tracing?.address,
+    tracingEndpoint = (config?.Spec?.Observability?.tracing?.endpoint || '/api/v2/spans'),
+    tracingLimitedID = config?.Spec?.Observability?.tracing?.sampledFraction && (+config.Spec.Observability.tracing.sampledFraction * Math.pow(2, 63)),
     logZipkin = tracingAddress && new logging.JSONLogger('zipkin').toHTTP('http://' + tracingAddress + tracingEndpoint, {
       batch: {
         timeout: 1,

--- a/pkg/sidecar/providers/pipy/repo/jobs.go
+++ b/pkg/sidecar/providers/pipy/repo/jobs.go
@@ -284,13 +284,14 @@ func features(s *Server, proxy *pipy.Proxy, pipyConf *PipyConf) {
 		proxy.MeshConf = meshConf
 		pipyConf.setSidecarLogLevel((*meshConf).GetMeshConfig().Spec.Sidecar.LogLevel)
 		pipyConf.setSidecarTimeout((*meshConf).GetMeshConfig().Spec.Sidecar.SidecarTimeout)
-		pipyConf.setRemoteLoggingLevel((*meshConf).GetMeshConfig().Spec.Observability.RemoteLogging.Level)
 		pipyConf.setEnableSidecarActiveHealthChecks((*meshConf).GetFeatureFlags().EnableSidecarActiveHealthChecks)
 		pipyConf.setEnableEgress((*meshConf).IsEgressEnabled())
 		pipyConf.setHTTP1PerRequestLoadBalancing((*meshConf).GetMeshConfig().Spec.Traffic.HTTP1PerRequestLoadBalancing)
 		pipyConf.setHTTP2PerRequestLoadBalancing((*meshConf).GetMeshConfig().Spec.Traffic.HTTP2PerRequestLoadBalancing)
 		pipyConf.setEnablePermissiveTrafficPolicyMode((*meshConf).IsPermissiveTrafficPolicyMode())
-		pipyConf.setLocalDNSProxy((*meshConf).IsLocalDNSProxyEnabled(), (*meshConf).GetLocalDNSProxyPrimaryUpstream(), (*meshConf).GetLocalDNSProxySecondaryUpstream())
+		pipyConf.setLocalDNSProxy((*meshConf).IsLocalDNSProxyEnabled(), meshConf)
+		pipyConf.setObservabilityTracing((*meshConf).IsTracingEnabled(), meshConf)
+		pipyConf.setObservabilityRemoteLogging((*meshConf).IsRemoteLoggingEnabled(), meshConf)
 		clusterProps := (*meshConf).GetMeshConfig().Spec.ClusterSet.Properties
 		if len(clusterProps) > 0 {
 			pipyConf.Spec.ClusterSet = make(map[string]string)

--- a/pkg/sidecar/providers/pipy/repo/policy.go
+++ b/pkg/sidecar/providers/pipy/repo/policy.go
@@ -11,6 +11,7 @@ import (
 
 	multiclusterv1alpha1 "github.com/openservicemesh/osm/pkg/apis/multicluster/v1alpha1"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/k8s"
@@ -40,16 +41,11 @@ func (p *PipyConf) setSidecarTimeout(sidecarTimeout int) (update bool) {
 	return
 }
 
-func (p *PipyConf) setRemoteLoggingLevel(remoteLoggingLevel uint16) (update bool) {
-	if update = p.Spec.RemoteLoggingLevel != remoteLoggingLevel; update {
-		p.Spec.RemoteLoggingLevel = remoteLoggingLevel
-	}
-	return
-}
-
-func (p *PipyConf) setLocalDNSProxy(enable bool, primary, secondary string) {
+func (p *PipyConf) setLocalDNSProxy(enable bool, conf *configurator.Configurator) {
 	if enable {
 		p.Spec.LocalDNSProxy = new(LocalDNSProxy)
+		primary := (*conf).GetLocalDNSProxyPrimaryUpstream()
+		secondary := (*conf).GetLocalDNSProxySecondaryUpstream()
 		if len(primary) > 0 || len(secondary) > 0 {
 			p.Spec.LocalDNSProxy.UpstreamDNSServers = new(UpstreamDNSServers)
 			if len(primary) > 0 {
@@ -61,6 +57,32 @@ func (p *PipyConf) setLocalDNSProxy(enable bool, primary, secondary string) {
 		}
 	} else {
 		p.Spec.LocalDNSProxy = nil
+	}
+}
+
+func (p *PipyConf) setObservabilityTracing(enable bool, conf *configurator.Configurator) {
+	if enable {
+		p.Spec.Observability.Tracing = &TracingSpec{
+			Address:         fmt.Sprintf("%s:%d", (*conf).GetTracingHost(), (*conf).GetTracingPort()),
+			Endpoint:        (*conf).GetTracingEndpoint(),
+			SampledFraction: fmt.Sprintf("%0.2f", (*conf).GetTracingSampledFraction()),
+		}
+	} else {
+		p.Spec.Observability.Tracing = nil
+	}
+}
+
+func (p *PipyConf) setObservabilityRemoteLogging(enable bool, conf *configurator.Configurator) {
+	if enable {
+		p.Spec.Observability.RemoteLogging = &RemoteLoggingSpec{
+			Level:           (*conf).GetRemoteLoggingLevel(),
+			Address:         fmt.Sprintf("%s:%d", (*conf).GetRemoteLoggingHost(), (*conf).GetRemoteLoggingPort()),
+			Endpoint:        (*conf).GetRemoteLoggingEndpoint(),
+			Authorization:   (*conf).GetRemoteLoggingAuthorization(),
+			SampledFraction: fmt.Sprintf("%0.2f", (*conf).GetRemoteLoggingSampledFraction()),
+		}
+	} else {
+		p.Spec.Observability.RemoteLogging = nil
 	}
 }
 

--- a/pkg/sidecar/providers/pipy/repo/types.go
+++ b/pkg/sidecar/providers/pipy/repo/types.go
@@ -209,20 +209,55 @@ type LocalDNSProxy struct {
 	UpstreamDNSServers *UpstreamDNSServers `json:"UpstreamDNSServers,omitempty"`
 }
 
+// TracingSpec is the type to represent tracing configuration.
+type TracingSpec struct {
+	// Address defines the tracing collectio's hostname.
+	Address string `json:"address,omitempty"`
+
+	// Endpoint defines the API endpoint for tracing requests sent to the collector.
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// SampledFraction defines the sampled fraction.
+	SampledFraction string `json:"sampledFraction,omitempty"`
+}
+
+// RemoteLoggingSpec is the type to represent remote logging configuration.
+type RemoteLoggingSpec struct {
+	// Level defines the remote logging's level.
+	Level uint16 `json:"level,omitempty"`
+	// Address defines the remote logging's hostname.
+	Address string `json:"address,omitempty"`
+	// Endpoint defines the API endpoint for remote logging requests sent to the collector.
+	Endpoint string `json:"endpoint,omitempty"`
+	// Authorization defines the access entity that allows to authorize someone in remote logging service.
+	Authorization string `json:"authorization,omitempty"`
+	// SampledFraction defines the sampled fraction.
+	SampledFraction string `json:"sampledFraction,omitempty"`
+}
+
+// ObservabilitySpec is the type to represent OSM's observability configurations.
+type ObservabilitySpec struct {
+	// Tracing defines OSM's tracing configuration.
+	Tracing *TracingSpec `json:"tracing,omitempty"`
+
+	// RemoteLogging defines OSM's remote logging configuration.
+	RemoteLogging *RemoteLoggingSpec `json:"remoteLogging,omitempty"`
+}
+
 // MeshConfigSpec represents the spec of mesh config
 type MeshConfigSpec struct {
-	SidecarLogLevel    string
-	SidecarTimeout     int
-	RemoteLoggingLevel uint16
-	Traffic            TrafficSpec
-	FeatureFlags       FeatureFlags
-	Probes             struct {
+	SidecarLogLevel string
+	SidecarTimeout  int
+	Traffic         TrafficSpec
+	FeatureFlags    FeatureFlags
+	Probes          struct {
 		ReadinessProbes []v1.Probe `json:"ReadinessProbes,omitempty"`
 		LivenessProbes  []v1.Probe `json:"LivenessProbes,omitempty"`
 		StartupProbes   []v1.Probe `json:"StartupProbes,omitempty"`
 	}
 	ClusterSet    map[string]string
-	LocalDNSProxy *LocalDNSProxy `json:"LocalDNSProxy,omitempty"`
+	LocalDNSProxy *LocalDNSProxy    `json:"LocalDNSProxy,omitempty"`
+	Observability ObservabilitySpec `json:"Observability,omitempty"`
 }
 
 // Certificate represents an x509 certificate.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
1. move sidecar's ENVs into config.json
2. add osm.sidecarDisabledMTLS
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Done
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-edge-docs](https://github.com/flomesh-io/osm-docs/) repo (if applicable)? no